### PR TITLE
UCBG-319: Update functions to add final return clause

### DIFF
--- a/functions/botgarden/findhybridaffinhtml.sql
+++ b/functions/botgarden/findhybridaffinhtml.sql
@@ -1,4 +1,4 @@
--- function to return html formatted hybrid name
+-- function to return formatted hybrid name
 
 create or replace function findhybridaffinhtml (tigid varchar)
 returns varchar

--- a/functions/botgarden/findhybridaffinname.sql
+++ b/functions/botgarden/findhybridaffinname.sql
@@ -110,6 +110,12 @@ IMMUTABLE
 RETURNS NULL ON NULL INPUT;
 
 /*
+select pg_get_functiondef(oid)
+from pg_proc
+where proname = 'findhybridaffinhtml';
+
+-- drop function findhybridaffinhtml (tigid varchar);
+
 -- hybridflag is false and affinitytaxon is null
 select id, regexp_replace(taxon, '^.*\)''(.*)''$', '\1'),
 	findhybridaffinname(id), findhybridaffinhtml(id)


### PR DESCRIPTION
Updated findhybridaffinhtml and findhybridaffinname functions to add final return clause to fix db error:

ERROR:  control reached end of function without RETURN
CONTEXT:  PL/pgSQL function findhybridaffinname(character varying)
