### PR TITLE
BAMPFA-242: Updated CineFiles denorm sources

### DIFF
--- a/datasources/cinefiles/docauthoridstring.sql
+++ b/datasources/cinefiles/docauthoridstring.sql
@@ -1,0 +1,14 @@
+-- docauthoridstring table used in cinefiles denorm
+-- CRH 7/31/2014
+
+create table cinefiles_denorm.docauthoridstring as
+SELECT
+   cast(co.objectnumber as bigint) doc_id, 
+   cinefiles_denorm.finddocauthorids(co.objectnumber) docauthorids
+FROM collectionobjects_common co
+INNER JOIN misc m
+   ON (co.id = m.id AND m.lifecyclestate <> 'deleted')
+WHERE (co.objectnumber ~ '^[0-9]+$' ) and co.recordstatus='approved'
+order by cast(co.objectnumber as bigint);
+
+grant select on cinefiles_denorm.docauthoridstring to group reporters;

--- a/datasources/cinefiles/doclist_view.sql
+++ b/datasources/cinefiles/doclist_view.sql
@@ -1,5 +1,6 @@
 -- doclist_view, used in CineFiles denorm as primary source for searching documents
 -- CRH 2/23/2014
+-- CRH 7/31/2014 adding doc author ids for Mediatrope
 
 -- drop table cinefiles_denorm.doclist_view;
 
@@ -14,7 +15,7 @@ select
    cinefiles_denorm.getdispl(cc.source) source,
    cinefiles_denorm.getshortid(cc.source) src_id,
    das.docauthors author,
-   2 as name_id, -- not used?
+   daids.docauthorids as name_id, -- not used?
    dls.doclanguages doclanguage,
    sdg.datedisplaydate pubdate, 
   case when (cc.accesscode is null or cc.accesscode = '') 
@@ -79,6 +80,8 @@ from
       ON (cast(co.objectnumber as bigint) = dss.doc_id)
    LEFT OUTER JOIN cinefiles_denorm.docnamesubjectstring dnss
       ON (cast(co.objectnumber as bigint) = dnss.doc_id)
+   LEFT OUTER JOIN cinefiles_denorm.docauthoridstring daids
+      ON (cast(co.objectnumber as bigint) = daids.doc_id)
 WHERE (co.objectnumber ~ '^[0-9]+$' ) and co.recordstatus='approved'
 order by cast(co.objectnumber as bigint);
 

--- a/datasources/cinefiles/filmlist_view.sql
+++ b/datasources/cinefiles/filmlist_view.sql
@@ -1,6 +1,7 @@
 -- filmlist_view.sql, used in cinefiles_denorm
 -- gets concatenated strings for repeating information insteaad of cartesian products
 -- CRH 2/23/2014
+-- CRH 7/31/2014 adding production company identifiers for Mediatrope
 
 -- drop table cinefiles_denorm.filmlist_view
 
@@ -19,7 +20,8 @@ SELECT
    fps.filmprodcos prodco,
    fss.filmsubjects subject,
    fgs.filmgenres genre,
-   fts.filmtitles title
+   fts.filmtitles title,
+   fpids.filmprodcoids prodco_id
 FROM
    hierarchy h1
    INNER JOIN works_common wc
@@ -40,6 +42,7 @@ FROM
    LEFT OUTER JOIN cinefiles_denorm.filmtitlestring fts on (wc.shortidentifier=fts.filmid)
    LEFT OUTER JOIN cinefiles_denorm.filmprodcostring fps on (wc.shortidentifier=fps.filmid)
    LEFT OUTER JOIN cinefiles_denorm.filmdoccount fdc on (wc.shortidentifier=fdc.filmid)
+   LEFT OUTER JOIN cinefiles_denorm.filmprodcoidstring fpids on (wc.shortidentifier=fpids.filmid)   
 where fdc.doccount is not null
 order by wc.shortidentifier;
 

--- a/datasources/cinefiles/filmprodcoidstring.sql
+++ b/datasources/cinefiles/filmprodcoidstring.sql
@@ -1,0 +1,14 @@
+-- filmprodcoidstring table used in cinefiles denorm
+-- CRH 7/31/2014
+
+create table cinefiles_denorm.filmprodcoidstring as
+SELECT
+   wc.shortidentifier filmId, 
+   cinefiles_denorm.findfilmprodcoids(wc.shortidentifier) filmprodcoids
+FROM works_common wc
+INNER JOIN misc m
+   ON (wc.id = m.id AND m.lifecyclestate <> 'deleted')
+-- WHERE cinefiles_denorm.findfilmprodcos(wc.shortidentifier) is not null
+ORDER BY wc.shortidentifier;
+
+grant select on cinefiles_denorm.filmprodcoidstring to group reporters;

--- a/datasources/cinefiles/organizationlist.sql
+++ b/datasources/cinefiles/organizationlist.sql
@@ -1,0 +1,24 @@
+-- organizationlist.sql, used in cinefiles_denorm
+-- gets lookup table of persons, for use by Mediatrope
+-- CRH 7/31/2014
+
+-- drop table cinefiles_denorm.organizationlist
+
+-- organizationlist.sql, used in cinefiles_denorm
+-- gets lookup table of persons, for use by Mediatrope
+-- CRH 7/31/2014
+
+-- drop table cinefiles_denorm.organizationlist
+
+create table cinefiles_denorm.organizationlist as
+select 
+   cinefiles_denorm.getshortid(oc.refname) as shortid, 
+   cinefiles_denorm.getdispl(oc.refname) as orgname,
+   cc.updatedat
+from organizations_common oc
+join misc on misc.id=oc.id
+join collectionspace_core cc on oc.id=cc.id
+where misc.lifecyclestate <> 'deleted'
+order by orgname;
+
+grant select on cinefiles_denorm.organizationlist to group reporters;

--- a/datasources/cinefiles/personlist.sql
+++ b/datasources/cinefiles/personlist.sql
@@ -1,0 +1,18 @@
+-- personlist.sql, used in cinefiles_denorm
+-- gets lookup table of persons, for use by Mediatrope
+-- CRH 7/31/2014
+
+-- drop table cinefiles_denorm.personlist
+
+create table cinefiles_denorm.personlist as
+select 
+   cinefiles_denorm.getshortid(pc.refname) as shortid, 
+   cinefiles_denorm.getdispl(pc.refname) as personname,
+   cc.updatedat
+from persons_common pc
+join misc on misc.id=pc.id
+join collectionspace_core cc on pc.id=cc.id
+where misc.lifecyclestate <> 'deleted'
+order by personname;
+
+grant select on cinefiles_denorm.personlist to group reporters;

--- a/functions/cinefiles/finddocauthorids.sql
+++ b/functions/cinefiles/finddocauthorids.sql
@@ -1,0 +1,43 @@
+-- finddocauthorids.sql, return concatenated string of author ids, taking collection object objectNumber as input
+-- used in CineFiles denorm process
+-- CRH 7/31/2014
+
+create or replace function cinefiles_denorm.finddocauthorids(text)
+returns text
+as
+$$
+declare
+   docauthorstring text;
+   r text;
+
+begin
+
+docauthorstring := '';
+
+FOR r IN
+SELECT cinefiles_denorm.getshortid(oppg.objectproductionperson) docauthor
+FROM collectionobjects_common co
+LEFT OUTER JOIN hierarchy h2
+   ON (h2.parentid = co.id AND h2.primarytype = 'objectProductionPersonGroup')
+LEFT OUTER JOIN objectProductionPersonGroup oppg
+   ON (h2.id = oppg.id)
+WHERE co.objectnumber = $1
+ORDER BY h2.pos
+
+LOOP
+
+docauthorstring := docauthorstring || r || '|';
+
+END LOOP;
+
+if docauthorstring = '|' then docauthorstring = null;
+end if;
+
+docauthorstring := trim(trailing '|' from docauthorstring);
+
+return docauthorstring;
+end;
+$$
+LANGUAGE 'plpgsql'
+IMMUTABLE
+RETURNS NULL ON NULL INPUT;

--- a/functions/cinefiles/findfilmprodcoids.sql
+++ b/functions/cinefiles/findfilmprodcoids.sql
@@ -1,0 +1,44 @@
+-- return concatenated string of film production company ids, taking filmId shortidentifier as input
+-- used in CineFiles denorm process
+-- CRH 7/31/2014
+
+create or replace function cinefiles_denorm.findfilmprodcoids(text)
+returns text
+as
+$$
+declare
+   prodcostring text;
+   r text;
+
+begin
+
+prodcostring := '';
+
+FOR r IN
+SELECT cinefiles_denorm.getshortid(pg.publisher) filmProdco
+FROM hierarchy h1
+INNER JOIN works_common wc
+   ON ( h1.id = wc.id AND h1.primarytype = 'WorkitemTenant50' )
+LEFT OUTER JOIN hierarchy h5
+   ON ( h5.parentid = h1.id AND h5.primarytype = 'publisherGroup')
+LEFT OUTER JOIN publisherGroup pg
+   ON ( h5.id = pg.id )
+WHERE wc.shortidentifier = $1
+ORDER BY h5.pos
+LOOP
+
+prodcostring := prodcostring || r || '|';
+
+END LOOP;
+
+if prodcostring = '|' then prodcostring = null;
+end if;
+
+prodcostring := trim(trailing '|' from prodcostring);
+
+return prodcostring;
+end;
+$$
+LANGUAGE 'plpgsql'
+IMMUTABLE
+RETURNS NULL ON NULL INPUT;


### PR DESCRIPTION
For Mediatrope, personlist and organizationlist tables created on
cinefiles-dev.
updated filmlist_view on cinefiles-dev with prodco_id, using new
function and new intermediate table
updated doclist_view on cinefiles-dev with name_id (not 2), using new
function and new intermediate table
