### PR TITLE
CC-724: Add check for new install; update query to only insert new data

### DIFF
--- a/scripts/db/uoc_5.0_to_5.3.sql
+++ b/scripts/db/uoc_5.0_to_5.3.sql
@@ -134,7 +134,7 @@ BEGIN
             LOOP
                 -- Get max pos value for the UOC record's Location field, and generate a new uuid:
 
-                SELECT CASE WHEN max(pos) IS NULL THEN -1 ELSE max(pos) END INTO maxpos
+                SELECT coalesce(max(pos), -1) INTO maxpos
                 FROM public.uoc_common_locationlist
                 WHERE id = trow.id;
 
@@ -228,7 +228,7 @@ BEGIN
                 -- Get max pos value for the UOC record's Authorization group, and generate a new uuid:
 
                 SELECT
-                    CASE WHEN max(pos) IS NULL THEN -1 ELSE max(pos) END,
+                    coalesce(max(pos), -1),
                     uuid_generate_v4()::varchar
                 INTO
                     maxpos,
@@ -349,7 +349,7 @@ BEGIN
                 -- Get max pos value for the UOC record's Use Date group, and generate a new uuid:
 
                 SELECT
-                    CASE WHEN max(pos) IS NULL THEN -1 ELSE max(pos) END,
+                    coalesce(max(pos), -1),
                     uuid_generate_v4()::varchar
                 INTO
                     maxpos,

--- a/scripts/db/uoc_5.0_to_5.3.sql
+++ b/scripts/db/uoc_5.0_to_5.3.sql
@@ -1,6 +1,6 @@
-/* Use of Collections V1 Migration
+/* Use of Collections Data Migration from Version 5.0
 
--- This SQL script migrates existing Use of Collections data from V1 to incorporate new features developed by the UCB CSpace team, based on the following assumptions:
+-- This SQL script migrates existing Use of Collections data from Version 5.0 to incorporate new features developed by the UCB CSpace team, based on the following assumptions:
 
 	-- The appropriate database is specified in executing this script.
 	   This script does not contain commands to connect to the appropriate database.
@@ -8,36 +8,37 @@
 	-- New database changes have been made: e.g. new tables created, foreign keys added.
 
 	-- New records should not exist in newly created tables.
-	   Since this script may possibly be run repeatedly, it only creates a new record,
-	   if the record has not yet been migrated.
+	   But, since this script may possibly be run repeatedly, it checks for data in the new tables
+           and it only creates a new record if the record has not yet been migrated.
 
 	-- The uuid_generate_v4() function is required to generate UUID for new records.
 	   Installing the uuid-ossp extension will make all UUID generation functions available.
 	   This script creates and uses the uuid_generate_v4() function to generate a version 4 UUID.
 
-           --  To install the uuid-ossp extension:
+           -- To install the uuid-ossp extension and make all the UUID functions available:
  		CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
-	   -- To create the uuid_generate_v4() function:
+	   -- To only install the uuid_generate_v4() function to generate Type 4 UUIDs:
 		CREATE OR REPLACE FUNCTION public.uuid_generate_v4()
 		  RETURNS uuid
 		  LANGUAGE c
 		  PARALLEL SAFE STRICT
 		AS '$libdir/uuid-ossp', $function$uuid_generate_v4$function$;
 
-	-- Once existing data has been migrated, this script does not delete data, nor drop the newly obsolete columns.
+	-- Once existing data has been migrated, this script does not delete data from,
+           nor drop the newly obsolete columns.
 
--- V1 Use of Collections tables:
+-- Version 5.0 Use of Collections tables:
 	
-	public.uoc_common ============> Various fields updated to repeatable fields/groups
-	public.uoc_common_methodlist => NO MIGRATION NEEDED
-	public.usergroup =============> NO MIGRATION NEEDED
+	public.uoc_common ============> MIGRATION NEEDED: various fields updated to repeatable fields/groups.
+	public.uoc_common_methodlist => NO MIGRATION NEEDED.
+	public.usergroup =============> NO MIGRATION NEEDED, although 3 new fields were added to the table.
 	
--- V1 uoc_common table description:
+-- Version 5.0 uoc_common table description and migration note:
 	
 	                            Table "public.uoc_common"
 	      Column       |            Type             | Nullable | Migrate To
-	-------------------+-----------------------------+----------+-------------
+	-------------------+-----------------------------+----------+------------------------
 	 id                | character varying(36)       | not null |
 	 enddate           | timestamp without time zone |          |
 	 location          | character varying           |          | uoc_common_locationlist
@@ -65,7 +66,7 @@
 	uoc_common.result
 	uoc_common.referencenumber
 	
--- REPEATABLE FIELDS: The following uoc_common columns are now repeatable fields; migrated as follows:
+-- REPEATABLE FIELDS: The following uoc_common columns are now repeatable fields; migration path:
 	
 	uoc_common.location ==========> uoc_common_locationlist.item
 	uoc_common.authorizationdate => authorizationgroup.authorizationdate
@@ -74,9 +75,18 @@
 	uoc_common.startsingledate ===> usedategroup.usedate
 
 */
+
+
+-- 1) Create function uuid_generate_v4() for generating UUID before migration:
+
+CREATE OR REPLACE FUNCTION public.uuid_generate_v4()
+ RETURNS uuid
+ LANGUAGE c
+ PARALLEL SAFE STRICT
+AS '$libdir/uuid-ossp', $function$uuid_generate_v4$function$
 	
 
-/* 1) Migrate uoc_common.location data to uoc_common_locationlist table:
+/* 2) Migrate v5.0 UOC Location data to uoc_common_locationlist table:
 
 -- NEW uoc_common_locationlist table description:
 	
@@ -91,36 +101,59 @@
 	Foreign-key constraints:
 	    "uoc_common_locationlist_id_hierarchy_fk" FOREIGN KEY (id) REFERENCES hierarchy(id) ON DELETE CASCADE
 
--- Since there is only <= 1 value for uoc_common.location, uoc_common_locationlist.pos can be set to 0.
--- Only add a new record when there is a value for uoc_common.location, and if the record does not yet exist.
--- Do not create empty records in uoc_common_locationlist.
+-- Migration path for uoc_common.location:
 
 	uoc_common.id ========> uoc_common_locationlist.id
-	0 ====================> uoc_common_locationlist.pos
+	0 or next pos value ==> uoc_common_locationlist.pos
 	uoc_common.location ==> uoc_common_locationlist.item
 
--- Insert a new record into uoc_common_locationlist table.
--- Only add a new record when there is a value for location.
--- Do not create empty records in uoc_common_locationlist.
--- Only add the record if it does NOT already exist:
-
-INSERT INTO public.uoc_common_locationlist (
-	id, 
-	pos, 
-	item)
-SELECT
-	id,
-	0,
-	location
-FROM public.uoc_common
-WHERE location IS NOT NULL
-AND location != ''
-ON CONFLICT DO NOTHING;
+-- Only add a new record to uoc_common_locationlist when there is a value for location; do not create empty records.
+-- Only add the record if it does NOT already exist.
+-- In the case of a new install, check for the uoc_common.location column and do nothing if it does not exist.
 
 */
 
+-- Insert a new record into uoc_common_locationlist table.
 
-/* 2) Migrate uoc_common authorization data to authorizationgroup table:
+DO $$
+DECLARE
+    trow record;
+    maxpos int;
+BEGIN
+    -- For new install, if uoc_common.location does not exist, there is nothing to migrate.
+
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='uoc_common' AND column_name='location') THEN
+        FOR trow IN
+            -- Get record in uoc_common that does not have an existing/matching record in uoc_common_locationlist:
+
+            SELECT uc.id, uc.location
+            FROM public.uoc_common uc
+            LEFT OUTER JOIN public.uoc_common_locationlist ucll ON (uc.id = ucll.id AND uc.location != ucll.item)
+            WHERE uc.location IS NOT NULL AND uc.location != '' AND ucll.item IS NULL  
+
+            LOOP
+                -- Get max pos value for the UOC record's Location field, and generate a new uuid:
+
+                SELECT CASE WHEN max(pos) IS NULL THEN -1 ELSE max(pos) END INTO maxpos
+                FROM public.uoc_common_locationlist
+                WHERE id = trow.id;
+
+                -- Migrate uoc_common Location data to uoc_common_locationlist table:
+
+                INSERT INTO public.uoc_common_locationlist (id, pos, item)
+                VALUES (trow.id, maxpos + 1, trow.location);
+
+            END LOOP;
+
+    ELSE
+        RAISE NOTICE 'No v5.0 UOC data to migrate: uoc_common.location DOES NOT EXIST';
+
+    END IF;
+END
+$$;
+
+
+/* 3) Migrate v5.0 UOC Authorization data to authorizationgroup table:
 
 -- NEW authorizationgroup table description:
 
@@ -137,18 +170,18 @@ ON CONFLICT DO NOTHING;
 	Foreign-key constraints:
 	    "authorizationgroup_id_hierarchy_fk" FOREIGN KEY (id) REFERENCES hierarchy(id) ON DELETE CASCADE
 
--- Migrate/add from uoc_common to hierarchy.
+-- Migrate/add data from uoc_common to hierarchy.
 -- The foreign key on the authorizationgroup table requires first adding new records to hierarchy.
 -- Use the uuid_generate_v4() function to generate a new type 4 UUID for the new record.
 
-	uuid_generate_v4()::varchar as id ====> hierarchy.id
+	uuid_generate_v4()::varchar AS id ====> hierarchy.id
 	uoc_common.id ========================> hierarchy.parentid
 	0 ====================================> hierarchy.pos
 	'uoc_common:authorizationGroupList' ==> hierarchy.name
 	True =================================> hierarchy.isproperty
 	'authorizationGroup' =================> hierarchy.primarytype
 
--- Migrate from uoc_common to authorizationgroup:
+-- Migrate data from uoc_common to authorizationgroup:
 -- Only add a new record when there is a value for authorizationdate, authorizationnote, or authorizedby.
 -- Do not create empty records in authorizationgroup.
 
@@ -159,79 +192,92 @@ ON CONFLICT DO NOTHING;
 
 */
 
--- Create function uuid_generate_v4() for generating UUID:
+-- Migrate/add Authorization data to hierarchy, authorizationgroup tables.
 
-CREATE OR REPLACE FUNCTION public.uuid_generate_v4()
- RETURNS uuid
- LANGUAGE c
- PARALLEL SAFE STRICT
-AS '$libdir/uuid-ossp', $function$uuid_generate_v4$function$
+DO $$
+DECLARE
+    trow record;
+    maxpos int;
+    agid varchar(36);
+BEGIN
 
--- Create temp table to hold data for populating authorizationgroup and hierarchy tables:
+    -- For new install, if uoc_common.authorizedby does not exist, there is nothing to migrate.
 
-CREATE TEMP TABLE authgrouptemp AS
-SELECT 
-	uuid_generate_v4()::varchar AS id,
-	x.parentid,
-	x.authorizationdate, 
-	x.authorizationnote, 
-	x.authorizedby
-FROM (
-	SELECT
-		uc.id AS parentid,
-		uc.authorizationdate, 
-		uc.authorizationnote, 
-		uc.authorizedby
-	FROM public.uoc_common uc
-	WHERE uc.authorizationdate IS NOT NULL
-	OR uc.authorizationnote IS NOT NULL
-	OR uc.authorizedby IS NOT NULL
-	UNION ALL
-	SELECT
-		h.parentid,
-		ag.authorizationdate, 
-		ag.authorizationnote, 
-		ag.authorizedby
-	FROM public.authorizationgroup ag
-	JOIN public.hierarchy h ON (ag.id = h.id)
-	) x
-GROUP BY x.parentid, x.authorizationdate, x.authorizationnote, x.authorizedby
-HAVING count(*) = 1;
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='uoc_common' AND column_name='authorizedby') THEN
+        FOR trow IN
+            -- Get record in uoc_common that does not have an existing/matching record in authorizationgroup:
+            -- Only need to match the uoc_common.id as there is only one data set per UOC record.
+            -- Verify that there is data to migrate.
 
--- Insert new records into hierarchy table first, due to foreign key on authorizationgroup table:
+            SELECT id AS parentid, authorizedby, authorizationdate, authorizationnote 
+            FROM public.uoc_common 
+            WHERE id not in (
+                SELECT uc.id
+                FROM public.uoc_common uc
+                JOIN public.hierarchy h ON (uc.id = h.parentid)
+                JOIN public.authorizationgroup ag ON (
+                    h.id = ag.id
+                    AND uc.authorizedby IS NOT DISTINCT FROM ag.authorizedby
+                    AND uc.authorizationdate IS NOT DISTINCT FROM ag.authorizationdate
+                    AND uc.authorizationnote IS NOT DISTINCT FROM ag.authorizationnote
+                )
+            AND (authorizedby IS NOT NULL OR authorizationdate IS NOT NULL OR authorizationnote IS NOT NULL)
+            )
 
-INSERT INTO public.hierarchy (
-	id, 
-	parentid, 
-	pos, 
-	name, 
-	isproperty, 
-	primarytype)
-SELECT
-	id,
-	parentid,
-	0,
-	'uoc_common:authorizationGroupList',
-	True,
-	'authorizationGroup'
-FROM authgrouptemp;	
+            LOOP
+                -- Get max pos value for the UOC record's Authorization group, and generate a new uuid:
 
--- Insert new records into authorizationgroup table:
+                SELECT
+                    CASE WHEN max(pos) IS NULL THEN -1 ELSE max(pos) END,
+                    uuid_generate_v4()::varchar
+                INTO
+                    maxpos,
+                    agid
+                FROM public.hierarchy
+                WHERE parentid = trow.parentid
+                AND primarytype = 'authorizationGroup';
 
-INSERT INTO public.authorizationgroup (
-	id, 
-	authorizationdate, 
-	authorizationnote, 
-	authorizedby)
-SELECT 
-	id,
-	authorizationdate, 
-	authorizationnote, 
-	authorizedby
-FROM authgrouptemp;
+                -- Insert new record into hierarchy table first, due to foreign key on authorizationgroup table:
+
+                INSERT INTO public.hierarchy (
+                    id,
+                    parentid,
+                    pos,
+                    name,
+                    isproperty,
+                    primarytype)
+                VALUES (
+                    agid,
+                    trow.parentid,
+                    maxpos + 1,
+                    'uoc_common:authorizationGroupList',
+                    true,
+                    'authorizationGroup');
+
+                -- Migrate uoc_common Authorization data into authorizationgroup table:
+
+                INSERT INTO public.authorizationgroup (
+                    id, 
+                    authorizedby,
+                    authorizationdate, 
+                    authorizationnote)
+                VALUES ( 
+                    agid,
+                    trow.authorizedby,
+                    trow.authorizationdate, 
+                    trow.authorizationnote);
+
+            END LOOP;
+
+    ELSE
+        RAISE NOTICE 'No v5.0 UOC data to migrate: uoc_common.authorizedby DOES NOT EXIST';
+
+    END IF;
+END
+$$;
 
 
-/* 3) Migrate uoc_common.startsingledate data to usedategroup table:
+/* 4) Migrate v5.0 UOC Start/single date data to usedategroup table:
 	
 -- NEW usedategroup table description:
 
@@ -249,18 +295,18 @@ FROM authgrouptemp;
 	Foreign-key constraints:
 	    "usedategroup_id_hierarchy_fk" FOREIGN KEY (id) REFERENCES hierarchy(id) ON DELETE CASCADE
 
--- Migrate/add from uoc_common to hierarchy.
+-- Migrate/add data from uoc_common to hierarchy.
 -- The foreign key on the usedategroup table requires first adding new records to hierarchy.
 -- Use the uuid_generate_v4() function to generate a new type 4 UUID for the new record.
 
-	uuid_generate_v4()::varchar as id ====> hierarchy.id
+	uuid_generate_v4()::varchar AS id ====> hierarchy.id
 	uoc_common.id ========================> hierarchy.parentid
 	0 ====================================> hierarchy.pos
 	'uoc_common:useDateGroupList' ========> hierarchy.name
 	True =================================> hierarchy.isproperty
 	'useDateGroup' =======================> hierarchy.primarytype
 
--- Migrate from uoc_common to usedategroup.
+-- Migrate data from uoc_common to usedategroup.
 -- Only add a new record when there is a value for startsingledate.
 -- Do not create empty records in usedategroup.
 
@@ -269,55 +315,82 @@ FROM authgrouptemp;
 
 */
 
--- Create temp table to hold data for populating usedategroup and hierarchy tables:
+-- Migrate/add Start/single datA data to hierarchy, usedategroup tables.
 
-CREATE TEMP TABLE usedategrouptemp AS
-SELECT
-        uuid_generate_v4()::varchar AS id,
-        x.parentid,
-        x.usedate
-FROM (
-        SELECT
-                uc.id AS parentid,
-                uc.startsingledate AS usedate
-        FROM public.uoc_common uc
-        WHERE startsingledate IS NOT NULL;
-        UNION ALL
-        SELECT
-                h.parentid,
-                udg.usedate
-        FROM public.usedategroup udg
-        JOIN public.hierarchy h ON (udg.id = h.id)
-        ) x
-GROUP BY x.parentid, x.usedate
-HAVING count(*) = 1;
+DO $$
+DECLARE
+    trow record;
+    maxpos int;
+    udgid varchar(36);
+BEGIN
 
--- Insert new records into hierarchy table first, due to foreign key on usedategroup table to hierarchy.id:
+    -- For new install, if uoc_common.startsingledate does not exist, there is nothing to migrate.
 
-INSERT INTO public.hierarchy (
-	id, 
-	parentid, 
-	pos, 
-	name, 
-	isproperty, 
-	primarytype)
-SELECT
-	id,
-	parentid,
-	0,
-	'uoc_common:useDateGroupList',
-	True,
-	'useDateGroup'
-FROM usedategrouptemp;
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='uoc_common' AND column_name='startsingledate') THEN
+        FOR trow IN
+            -- Get record in uoc_common that does not have an existing/matching record in usedategroup.
+            -- Only need to match the uoc_common.id as there is only one data set per UOC record.
+            -- Verify that there is data to migrate.
 
--- Insert new records into usedategroup table:
+            SELECT id AS parentid, startsingledate AS usedate
+            FROM public.uoc_common
+            WHERE id NOT IN (
+                SELECT uc.id
+                FROM public.uoc_common uc
+                JOIN public.hierarchy h ON (uc.id = h.parentid)
+                JOIN public.usedategroup udg ON (
+                    h.id = udg.id
+                    AND uc.startsingledate IS NOT DISTINCT FROM ag.usedate
+                )
+            AND startsingledate IS NOT NULL
+            )
 
-INSERT INTO public.usedategroup (
-	id, 
-	usedate)
-SELECT 
-	id,
-	startsingledate
-FROM usedategrouptemp;
+            LOOP
+                -- Get max pos value for the UOC record's Use Date group, and generate a new uuid:
+
+                SELECT
+                    CASE WHEN max(pos) IS NULL THEN -1 ELSE max(pos) END,
+                    uuid_generate_v4()::varchar
+                INTO
+                    maxpos,
+                    udgid
+                FROM public.hierarchy
+                WHERE parentid = trow.parentid
+                AND primarytype = 'useDateGroup';
+
+                -- Insert new record into hierarchy table first, due to foreign key on usedategroup table:
+
+                INSERT INTO public.hierarchy (
+                    id,
+                    parentid,
+                    pos,
+                    name,
+                    isproperty,
+                    primarytype)
+                VALUES (
+                    udgid,
+                    trow.parentid,
+                    maxpos + 1,
+                    'uoc_common:useDateGroupList',
+                    true,
+                    'useDateGroup');
+
+                -- Insert new record into authorizationgroup table:
+
+                INSERT INTO public.usedategroup (
+                    id, 
+                    usedate)
+                VALUES ( 
+                    udgid,
+                    trow.usedate);
+
+            END LOOP;
+
+    ELSE
+        RAISE NOTICE 'No v5.0 UOC data to migrate: uoc_common.startsingledate DOES NOT EXIST';
+
+    END IF;
+END
+$$;
 
 -- END OF MIGRATION

--- a/scripts/db/uoc_5.0_to_5.3.sql
+++ b/scripts/db/uoc_5.0_to_5.3.sql
@@ -221,8 +221,8 @@ BEGIN
                     AND uc.authorizationdate IS NOT DISTINCT FROM ag.authorizationdate
                     AND uc.authorizationnote IS NOT DISTINCT FROM ag.authorizationnote
                 )
-            AND (authorizedby IS NOT NULL OR authorizationdate IS NOT NULL OR authorizationnote IS NOT NULL)
             )
+            AND (authorizedby IS NOT NULL OR authorizationdate IS NOT NULL OR authorizationnote IS NOT NULL)
 
             LOOP
                 -- Get max pos value for the UOC record's Authorization group, and generate a new uuid:
@@ -342,8 +342,8 @@ BEGIN
                     h.id = udg.id
                     AND uc.startsingledate IS NOT DISTINCT FROM ag.usedate
                 )
-            AND startsingledate IS NOT NULL
             )
+            AND startsingledate IS NOT NULL
 
             LOOP
                 -- Get max pos value for the UOC record's Use Date group, and generate a new uuid:


### PR DESCRIPTION
1) Check for new install. If v5.0 columns do not exist, there is nothing to migrate, so do nothing.
2) Update query to only migrate v5.0 data if it does not yet exist in new tables.